### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk: oraclejdk8
 before_install: chmod +x gradlew
 
 install: ./gradlew assemble --no-daemon
-script: travis_wait 20 ./gradlew check --no-daemon
+script: travis_wait 20 ./gradlew check --no-daemon --scan
 
 after_success:
   - ./gradlew jacocoTestReport --no-daemon

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'com.gradle.build-scan' version '2.1'
     id 'groovy'
     id 'jacoco'
     id 'java-gradle-plugin'
@@ -10,6 +11,11 @@ plugins {
     id 'ru.vyarus.github-info' version '1.1.0'
     id 'com.github.ben-manes.versions' version '0.20.0'
     id "pl.droidsonroids.jacoco.testkit" version "1.0.3"
+}
+
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 sourceCompatibility = 1.7


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.