### PR TITLE
Gradle bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'signing'
     id 'net.researchgate.release' version '3.0.2'
     id 'ru.vyarus.quality' version '4.9.0'
-    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.2.0'
     id 'ru.vyarus.java-lib' version '2.4.0'
     id 'ru.vyarus.github-info' version '1.5.0'
     id 'com.github.ben-manes.versions' version '0.46.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.plugin-publish' version '0.21.0'
+    id 'com.gradle.plugin-publish' version '1.1.0'
     id 'java-gradle-plugin'
     id 'groovy'
     id 'jacoco'
@@ -56,7 +56,7 @@ nexusPublishing {
 }
 
 // skip signing for jitpack (snapshots)
-tasks.withType(Sign) {onlyIf { !System.getenv('JITPACK') }}
+tasks.withType(Sign) { onlyIf { !System.getenv('JITPACK') } }
 
 // Required signing properties for release: signing.keyId, signing.password and signing.secretKeyRingFile
 // (https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials)
@@ -72,17 +72,15 @@ gradlePlugin {
             id = 'ru.vyarus.animalsniffer'
             displayName = project.description
             implementationClass = 'ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferPlugin'
+            description = 'Gradle AnimalSniffer plugin for Java, Groovy, Kotlin and Scala projects'
+            //tags = ['animalsniffer'] // Only after Gradle 7.5
         }
     }
 }
-pluginBundle {
-    description = 'Gradle AnimalSniffer plugin for Java, Groovy, Kotlin and Scala projects'
-    tags = ['animalsniffer']
 
-    mavenCoordinates {
-        groupId = project.group
-        artifactId = project.name
-    }
+pluginBundle {
+    // TODO move to gradlePlugin.plugins.animalsnifferPlugin.tags after using Gradle 7.5+
+    pluginTags = ['ru.vyarus.animalsniffer': ['animalsniffer']]
 }
 
 release.git.requireBranch.set('master')
@@ -91,7 +89,8 @@ afterReleaseBuild {
     dependsOn = [
             'publishMavenPublicationToSonatypeRepository',
             'closeAndReleaseSonatypeStagingRepository',
-            publishPlugins]
+            publishPlugins
+    ]
     doLast {
         logger.warn "RELEASED $project.group:$project.name:$project.version"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -73,14 +73,9 @@ gradlePlugin {
             displayName = project.description
             implementationClass = 'ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferPlugin'
             description = 'Gradle AnimalSniffer plugin for Java, Groovy, Kotlin and Scala projects'
-            //tags = ['animalsniffer'] // Only after Gradle 7.5
+            tags.add('animalsniffer')
         }
     }
-}
-
-pluginBundle {
-    // TODO move to gradlePlugin.plugins.animalsnifferPlugin.tags after using Gradle 7.5+
-    pluginTags = ['ru.vyarus.animalsniffer': ['animalsniffer']]
 }
 
 release.git.requireBranch.set('master')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/ru/vyarus/gradle/plugin/animalsniffer/AnimalSnifferExtension.groovy
+++ b/src/main/groovy/ru/vyarus/gradle/plugin/animalsniffer/AnimalSnifferExtension.groovy
@@ -80,7 +80,7 @@ class AnimalSnifferExtension extends CodeQualityExtension {
     /**
      * @param cache cache configuration closure
      */
-    void setCache(@DelegatesTo(value = CheckCacheExtension, strategy = Closure.DELEGATE_FIRST) Closure cache) {
+    void setCache(@DelegatesTo(value = CheckCacheExtension, strategy = Closure.OWNER_FIRST) Closure cache) {
         project.configure(this.cache, cache)
     }
 


### PR DESCRIPTION
I tried to move #59 along, you can see how to migrate it here.

There were some very major changes: https://plugins.gradle.org/docs/publish-plugin#publication

I did a similar migration here: https://github.com/gradle-nexus/publish-plugin/pull/168/files#diff-c0dfa6bc7a8685217f70a860145fbdf416d449eaff052fa28352c5cec1a98c06L8-L39

The most recent approach to configuring the publications is with this block:
https://github.com/gradle-nexus/publish-plugin/blob/94babb3f6aa1afb8bc18de129193aac51c200c51/build.gradle.kts#L226-L255

This allows us to edit POM, and artifact coordinates as well if necessary.

I got blocked on your custom plugin (ru.vyarus.java-lib) relying on old Gradle approaches incompatible with their new plugin.

This forcefully adds the sources and javadoc artifacts
https://github.com/xvik/gradle-java-lib-plugin/blob/abc5954dc0ea67dfc9f966eea00ca232d921537b/src/main/groovy/ru/vyarus/gradle/plugin/lib/JavaLibPlugin.groovy#L305-L306

So does `com.gradle.plugin-publish` ([`PublishPlugin.forceJavadocAndSourcesJars`](https://plugins.gradle.org/m2/com/gradle/publish/plugin-publish-plugin/1.1.0/plugin-publish-plugin-1.1.0-sources.jar))

There are also some breaking changes I noticed when I diffed the original `publishToMavenLocal` output (`~/.m2/ru/vyarus/`) and the new one (IntelliJ IDEA does .jar diffs extremely well).
